### PR TITLE
Update node-expat to ^2.4.1 for compatibility with Node.js v22

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "xml-streamer",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "xml-streamer",
-      "version": "1.0.0",
+      "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
         "lodash": "4.17.21",
-        "node-expat": "2.3.18"
+        "node-expat": "^2.4.1"
       },
       "devDependencies": {
         "mocha": "10.0.0",
@@ -2244,9 +2244,10 @@
       "dev": true
     },
     "node_modules/nan": {
-      "version": "2.16.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.16.0.tgz",
-      "integrity": "sha512-UdAqHyFngu7TfQKsCBgAA6pWDkT8MAO7d0jyOecVhN5354xbLqdn8mV9Tat9gepAupm0bt2DbeaSC8vS52MuFA=="
+      "version": "2.22.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.22.0.tgz",
+      "integrity": "sha512-nbajikzWTMwsW+eSsNm3QwlOs7het9gGJU5dDZzRTQGk03vyBOauxgI4VakDzE0PtsGTmXPsXTbbjVhRwR5mpw==",
+      "license": "MIT"
     },
     "node_modules/nanoid": {
       "version": "3.3.3",
@@ -2267,13 +2268,14 @@
       "dev": true
     },
     "node_modules/node-expat": {
-      "version": "2.3.18",
-      "resolved": "https://registry.npmjs.org/node-expat/-/node-expat-2.3.18.tgz",
-      "integrity": "sha512-9dIrDxXePa9HSn+hhlAg1wXkvqOjxefEbMclGxk2cEnq/Y3U7Qo5HNNqeo3fQ4bVmLhcdt3YN1TZy7WMZy4MHw==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/node-expat/-/node-expat-2.4.1.tgz",
+      "integrity": "sha512-uWgvQLgo883NKIL+66oJsK9ysKK3ej0YjVCPBZzO/7wMAuH68/Yb7+JwPWNaVq0yPaxrb48AoEXfYEc8gsmFbg==",
       "hasInstallScript": true,
+      "license": "MIT",
       "dependencies": {
         "bindings": "^1.5.0",
-        "nan": "^2.13.2"
+        "nan": "^2.19.0"
       }
     },
     "node_modules/normalize-path": {
@@ -5028,9 +5030,9 @@
       "dev": true
     },
     "nan": {
-      "version": "2.16.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.16.0.tgz",
-      "integrity": "sha512-UdAqHyFngu7TfQKsCBgAA6pWDkT8MAO7d0jyOecVhN5354xbLqdn8mV9Tat9gepAupm0bt2DbeaSC8vS52MuFA=="
+      "version": "2.22.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.22.0.tgz",
+      "integrity": "sha512-nbajikzWTMwsW+eSsNm3QwlOs7het9gGJU5dDZzRTQGk03vyBOauxgI4VakDzE0PtsGTmXPsXTbbjVhRwR5mpw=="
     },
     "nanoid": {
       "version": "3.3.3",
@@ -5045,12 +5047,12 @@
       "dev": true
     },
     "node-expat": {
-      "version": "2.3.18",
-      "resolved": "https://registry.npmjs.org/node-expat/-/node-expat-2.3.18.tgz",
-      "integrity": "sha512-9dIrDxXePa9HSn+hhlAg1wXkvqOjxefEbMclGxk2cEnq/Y3U7Qo5HNNqeo3fQ4bVmLhcdt3YN1TZy7WMZy4MHw==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/node-expat/-/node-expat-2.4.1.tgz",
+      "integrity": "sha512-uWgvQLgo883NKIL+66oJsK9ysKK3ej0YjVCPBZzO/7wMAuH68/Yb7+JwPWNaVq0yPaxrb48AoEXfYEc8gsmFbg==",
       "requires": {
         "bindings": "^1.5.0",
-        "nan": "^2.13.2"
+        "nan": "^2.19.0"
       }
     },
     "normalize-path": {

--- a/package.json
+++ b/package.json
@@ -24,15 +24,14 @@
     "url": "https://github.com/Sai1919/xml-streamer"
   },
   "dependencies": {
-    "node-expat": "2.3.18",
-    "lodash": "4.17.21"
+    "lodash": "4.17.21",
+    "node-expat": "^2.4.1"
   },
   "devDependencies": {
     "mocha": "10.0.0",
     "should": "13.2.3",
     "standard": "17.0.0"
   },
-  "optionalDependencies": {},
   "main": "./parser",
   "scripts": {
     "test": "mocha && standard"


### PR DESCRIPTION
C.f. [node-expat issue fixed in 2.4.1](https://github.com/xmppo/node-expat/issues/230)